### PR TITLE
Show file path in the repository

### DIFF
--- a/helm-cmd-t.el
+++ b/helm-cmd-t.el
@@ -276,10 +276,7 @@ specified, then it is used to construct the root-data. "
                                                    (helm-candidate-buffer))))
         for i in candidates
         for abs = (expand-file-name i root)
-        for disp = (if (and helm-ff-transformer-show-only-basename
-                            (not (helm-dir-is-dot i)))
-                       (helm-basename i)
-                     i)
+        for disp = i
         collect (cons (propertize disp 'face 'helm-ff-file) abs)))
 
 (defun helm-cmd-t-cache-p (line-count repo-type repo-root)
@@ -511,4 +508,3 @@ based on system type.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; helm-cmd-t.el ends here
-


### PR DESCRIPTION
With `helm-ff-transformer-show-only-basename` set to `t`, helm-cmd-t only displays a file's base name but not its path in the repository. This is annoying for a repository that has multiple files that have the same name.

However, `(set helm-ff-transformer-show-only-basename t)` makes `helm-find-files` too verbose.

I haven't checked other CVS, but at least `git --no-pager ls-files --full-name` returns a list of relative paths. Couldn't we simply ignore `helm-ff-transformer-show-only-basename`?
