### PR TITLE
Quote project root in format string

### DIFF
--- a/helm-cmd-t.el
+++ b/helm-cmd-t.el
@@ -139,9 +139,9 @@ see `grep-find-ignored-files' for inspiration."
 
 
 (defvar helm-cmd-t-repo-types
-  `(("git"         ".git"           "cd %d && git --no-pager ls-files --full-name")
-    ("hg"          ".hg"            "cd %d && hg manifest")
-    ("bzr"         ".bzr"           "cd %d && bzr ls --versioned")
+  `(("git"         ".git"           "cd '%d' && git --no-pager ls-files --full-name")
+    ("hg"          ".hg"            "cd '%d' && hg manifest")
+    ("bzr"         ".bzr"           "cd '%d' && bzr ls --versioned")
     ("dir-locals"  ".dir-locals.el" helm-cmd-t-get-find)
     (""            ""               helm-cmd-t-get-find))
   "root types supported.


### PR DESCRIPTION
Without this it's easy to cause an error if the directory name contains
shell syntax. E.g., in bash, try:

```
$ cd ~/One (Two) && echo oops
-bash: syntax error near unexpected token `('
```

To test the fix I invoked `helm-cmd-t` from a git repo whose path has a
left paren in it and no longer saw the above error reported in helm.
